### PR TITLE
reset series

### DIFF
--- a/src/charts/basic-histogram.js
+++ b/src/charts/basic-histogram.js
@@ -53,6 +53,7 @@ class BasicHistogram extends AbstractHighChart {
       });
     });
 
+    this.options.series = [];
     histograms.forEach((histogram, idx) => {
       this.options.series.push({
         name: data.ensembles[idx].name,


### PR DESCRIPTION
ヒストグラムを表示するときにデータがリセットされない問題を解消した。

ref: https://vizlab.slack.com/files/U027RMPRG/F8W8PKFJQ/screencapture-localhost-3000-1516588629455.png